### PR TITLE
Add `ox` XML parser as aws-sdk + ruby 3.0.0 no longer finds one on Bitrise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gem 'aws-sdk-s3', '~> 1'
 group :test do
   gem 'rspec'
   gem 'rubocop', '0.58.2'
+  gem 'ox'
 end


### PR DESCRIPTION
## Background

After Bitrise upgraded to Ruby 3.0.0, we got the following error this repo's Bitrise step (see end of this PR description). 

As a workaround, our issue was solved by manually adding an XML parser (`ox`, as I've had a lot of issues with `nokogiri` in side projects). 

This is probably due to a bug in `aws-sdk`, or we need to set their [PURE_ENV](https://github.com/aws/aws-sdk-ruby/blob/version-3/Gemfile#L21-L42) environment var. 

Either way, this was the fastest solution!

We also needed this on _all_ `bitrise-secure-s3-X` repos. Corresponding PRs on [download](https://github.com/DamienBitrise/bitrise-secure-s3-download/pull/1) and [delete](https://github.com/DamienBitrise/bitrise-secure-s3-delete/pull/1)

> Note: the error log is for the other secure-s3 repo but is the exact same error message

## Error log before fix

```
+------------------------------------------------------------------------------+
| (15) git::https://github.com/DamienBitrise/bitrise-secure-s3-delete@master   |
+------------------------------------------------------------------------------+
| id: https://github.com/DamienBitrise/bitrise-secure-s3-delete                |
| version: master                                                              |
| collection: git                                                              |
| toolkit: bash                                                                |
| time: 2021-06-02T21:52:14Z                                                   |
+------------------------------------------------------------------------------+
|                                                                              |
Successfully installed bundler-1.17.3
Parsing documentation for bundler-1.17.3
Done installing documentation for bundler after 1 seconds
1 gem installed
$ bundle install
$ bundle exec ruby /var/folders/dt/f5jq2d5s28l9mffwfy2h_n4h0000gn/T/bitrise148439363/step_src/step.rb
/Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml/parser.rb:96:in `<class:Parser>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml/parser.rb:7:in `<module:Xml>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml/parser.rb:5:in `<module:Aws>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml/parser.rb:3:in `<top (required)>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml.rb:8:in `require_relative'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core/xml.rb:8:in `<top (required)>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core.rb:68:in `require_relative'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-core-3.114.1/lib/aws-sdk-core.rb:68:in `<top (required)>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-kms-1.43.0/lib/aws-sdk-kms.rb:11:in `require'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-kms-1.43.0/lib/aws-sdk-kms.rb:11:in `<top (required)>'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-s3-1.95.1/lib/aws-sdk-s3.rb:11:in `require'
	from /Users/vagrant/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/aws-sdk-s3-1.95.1/lib/aws-sdk-s3.rb:11:in `<top (required)>'
	from /var/folders/dt/f5jq2d5s28l9mffwfy2h_n4h0000gn/T/bitrise148439363/step_src/step.rb:1:in `require'
	from /var/folders/dt/f5jq2d5s28l9mffwfy2h_n4h0000gn/T/bitrise148439363/step_src/step.rb:1:in `<main>'
```

## Error log after fix
```bash
+------------------------------------------------------------------------------+
| (7) git::https://github.com/DamienBitrise/bitrise-secure-s3-upload@master    |
+------------------------------------------------------------------------------+
| id: https://github.com/DamienBitrise/bitrise-secure-s3-upload                |
| version: master                                                              |
| collection: git                                                              |
| toolkit: bash                                                                |
| time: 2021-06-02T22:14:19Z                                                   |
+------------------------------------------------------------------------------+
|                                                                              |
Successfully installed bundler-1.17.3
Parsing documentation for bundler-1.17.3
Installing ri documentation for bundler-1.17.3
Done installing documentation for bundler after 2 seconds
1 gem installed
$ bundle install
$ bundle exec ruby /var/folders/dt/f5jq2d5s28l9mffwfy2h_n4h0000gn/T/bitrise048732646/step_src/step.rb
Params:
client_id: ***
secret: ***
bucket: [REDACTED]
region: [REDACTED]
object: ios/0c8fcf943585f59c.zip
filename: /Users/vagrant/git/DerivedData.zip
|                                                                              |
+---+---------------------------------------------------------------+----------+
| ✓ | git::https://github.com/DamienBitrise/bitrise-secure-s3-upl...| 33.02 sec|
+---+---------------------------------------------------------------+----------+
```